### PR TITLE
Implement first version of `Parse_command_line`

### DIFF
--- a/exp2.ml
+++ b/exp2.ml
@@ -654,7 +654,7 @@ module Script = struct
             return 13;
           ];
         );
-      List.concat begin
+      begin
         let minus_f = "one \nwith \\ spaces and \ttabs -dashes -- " in
         let make ret minus_g single =
           exits ret
@@ -676,7 +676,7 @@ module Script = struct
                       (return 44))
                 end
             ) in
-        [
+        List.concat [
           make 11 minus_f "";
           make 12 "not-one" "";
           make 11 "not-one" "-v";


### PR DESCRIPTION
The support is preliminary but the main pieces are there:
- only single-char options but this will be easy to extend since we use
  the “Manual Loop” [approach](http://mywiki.wooledge.org/BashFAQ/035).
- we don't give access to the list of anonymous arguments yet, we need to
  implement sequences/lists of strings in the EDSL.
- the function `Construct.parse_command_line` really behaves like `scanf`, the
  format specification gives the type of the expected function.

For now the help message generated by the tests is:

``` markdown
Usage string
with bunch of lines to
explain stuff

Options:

* `-f <string>`: String one
* `-g <string>`: String two
* `-v`: Bool one

```

We now have a few tests failing with KSH 93:

``` markdown
--------------------------------------------------------------------------------

Summary:

* Test "dash" ('dash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.46 s.
    - version: `"Version: 0.5.8-2.1ubuntu2"`.
* Test "bash" ('bash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.51 s.
    - version: `"GNU bash, version 4.3.46(1)-release (x86_64-pc-linux-gnu)"`.
* Test "sh" ('sh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.42 s.
    - version: `""`.
* Test "busybox" ('busybox' 'ash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.39 s.
    - version: `"BusyBox v1.22.1 (Ubuntu 1:1.22.0-15ubuntu1) multi-call binary."`.
* Test "ksh" ('ksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 12 / 55 failures
    - time: 0.49 s.
    - version: `"version         sh (AT&T Research) 93u+ 2012-08-01"`.
    - Cf. `/tmp/genspio-test-ksh-failures.txt`.
* Test "mksh" ('mksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.42 s.
    - version: `"Version: 52c-2"`.
* Test "posh" ('posh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.45 s.
    - version: `"Version: 0.12.6"`.
* Test "zsh" ('zsh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'):
    - 0 / 55 failures
    - time: 0.61 s.
    - version: `"zsh 5.1.1 (x86_64-ubuntu-linux-gnu)"`.

All “known” shells were tested ☺

--------------------------------------------------------------------------------
```
