### PR TITLE
Misc improvements

### DIFF
--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -16,8 +16,9 @@ val ( <$> ) : string t -> string t -> bool t
 val returns: 'a t -> value: int -> bool t
 (** Check the return value of a command/expression/script. *)
     
-val succeed : ?exit_with:int -> 'a t -> bool t
-val ( ~$ ) : 'a t -> bool t
+val succeeds : 'a t -> bool t
+(** [succeeds expr] is a equivalent to [returns expr ~value:0]. *)
+
 val nop : unit t
 val if_then_else :
   bool t -> unit t -> unit t -> unit t

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -3,6 +3,10 @@ type cli_option = Language.cli_option
 type 'a option_spec = 'a Language.option_spec
 type ('a, 'b) cli_options = ('a, 'b) Language.cli_options
 
+
+val fail: unit t
+(** Abort the script/command immediately. *)
+
 val exec : string list -> unit t
 val ( &&& ) : bool t -> bool t -> bool t
 val ( ||| ) : bool t -> bool t -> bool t

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -12,6 +12,10 @@ val ( &&& ) : bool t -> bool t -> bool t
 val ( ||| ) : bool t -> bool t -> bool t
 val ( =$= ) : string t -> string t -> bool t
 val ( <$> ) : string t -> string t -> bool t
+
+val returns: 'a t -> value: int -> bool t
+(** Check the return value of a command/expression/script. *)
+    
 val succeed : ?exit_with:int -> 'a t -> bool t
 val ( ~$ ) : 'a t -> bool t
 val nop : unit t

--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -25,18 +25,20 @@ let check_command s ~verifies =
   >>= fun results ->
   List.filter ~f:(fun (t, _) -> t = false) results |> return
 
-let command ?(args = []) s ~verifies = `Command (s, args, verifies)
+let command ?name ?(args = []) s ~verifies = `Command (name, s, args, verifies)
 
 let run_with_shell ~shell l =
   Pvem_lwt_unix.Deferred_list.while_sequential l ~f:(function
-    | `Command (s, args, verifies) ->
+    | `Command (name, s, args, verifies) ->
       check_command (shell s args) ~verifies
       >>= begin function
       | [] ->
         return None
       | failures ->
         return (Some (
-            (sprintf "#### Command:\n%s\n#### Args: %s\n#### Failures:\n%s\n" s
+            (sprintf "#### Command%s:\n%s\n#### Args: %s\n#### Failures:\n%s\n"
+               (Option.value_map name ~default:"" ~f:(sprintf " “%s”"))
+               s
                (String.concat ~sep:" " args)
                (List.map failures ~f:(fun (_, msg) -> sprintf "* %s" msg)
                 |> String.concat ~sep:"\n"))))

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -6,9 +6,11 @@ module Test = Tests.Test_lib
 module Compile = Genspio.Language
 module Construct = Genspio.EDSL
 
-let exits ?args n c = [
-  Test.command ?args (Compile.to_one_liner c) ~verifies:[`Exits_with n];
-  Test.command ?args (Compile.to_many_lines c) ~verifies:[`Exits_with n];
+let exits ?name ?args n c = [
+  Test.command ?name:(Option.map name (sprintf "%s; one-liner"))
+    ?args (Compile.to_one_liner c) ~verifies:[`Exits_with n];
+  Test.command ?name:(Option.map name (sprintf "%s; multi-liner"))
+    ?args (Compile.to_many_lines c) ~verifies:[`Exits_with n];
 ]
 
 let tests =

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -232,6 +232,39 @@ let tests =
           return 23;
         ]
       );
+    begin
+      let gives = 11 in
+      let does_not_give = 12 in
+      let t cmd yn value =
+        let name =
+          sprintf "%s %s %d" cmd
+            (if yn = gives then "returns" else "does not return") value in
+        exits ~name yn Construct.(
+            if_then_else
+              (exec ["sh"; "-c"; cmd] |> returns ~value)
+              (return gives)
+              (return does_not_give)
+          ) in
+      List.concat [
+        t "ls" gives 0;
+        t "ls /deijdsljidisjeidje" does_not_give 0;
+        t "ls /deijdsljidisjeidje" does_not_give 42;
+        t "exit 2" gives 2;
+        exits 21 ~name:"More complex return check" Construct.(
+            if_then_else
+              (seq [
+                  printf "I aaam so complex!\n";
+                  if_then_else (string "djsleidjs" =$=
+                                output_as_string (printf "diejliejjj"))
+                    (return 41)
+                    (return 42);
+                ]
+               |> returns ~value:42)
+              (return 21)
+              (return 22)
+          );
+      ]
+    end
   ]
 
 

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -201,7 +201,37 @@ let tests =
         make 0 "not-one" "-help";
         make 0 "not-one" "-h";
       ]
-    end
+    end;
+    exits 77 ~name:"die in a sequence" Construct.(
+        seq [
+          printf "Going to die";
+          fail;
+          return 42;
+        ]
+      );
+    exits 77 ~name:"cannot capture death itself" Construct.(
+        seq [
+          write_output
+            ~return_value:"/tmp/dieretval"
+            (seq [
+                printf "Going to die\n";
+                fail;
+                return 42;
+              ]);
+          return 23;
+        ]
+      );
+    exits 77 ~name:"cannot poison death either" Construct.(
+        seq [
+          string "dj ijdedej j42 ijde - '' "
+          >> seq [
+            printf "Going to die\n";
+            fail;
+            return 42;
+          ];
+          return 23;
+        ]
+      );
   ]
 
 

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -19,11 +19,11 @@ let tests =
     Construct.exec ["bash"; "-c"; sprintf "exit %d" n] in
   List.concat [
     exits 0 (Compile.Exec ["ls"]);
-    exits 18 Construct.(
-        ~$ (exec ["ls"])
-        &&& succeed ~exit_with:18 (seq [
+    exits 0 Construct.(
+        succeeds (exec ["ls"])
+        &&& returns ~value:18 (seq [
             exec ["ls"];
-            exec ["bash"; "-c"; "exit 2"]])
+            exec ["bash"; "-c"; "exit 18"]])
       );
     exits 23 Construct.(
         seq [
@@ -135,7 +135,7 @@ let tests =
     exits 10 Construct.(
         let tmp = "/tmp/test_loop_while" in
         let cat_potentially_empty =
-          if_then_else (exec ["cat"; tmp] |> succeed)
+          if_then_else (exec ["cat"; tmp] |> succeeds)
             nop
             (printf "") in
         seq [

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -67,20 +67,21 @@ let tests =
     exits 11 Construct.(
         let stdout = "/tmp/p1_out" in
         let stderr = "/tmp/p1_err" in
-        let return_value = "/tmp/p1_ret" in
+        let return_value_path = "/tmp/p1_ret" in
+        let return_value_value = 31 in
         let will_be_escaped =
           "newline:\n tab: \t \x42\b" in
         let will_not_be_escaped =
           "spaces, a;c -- ' - '' \\  ''' # ''''  @ ${nope} & ` ~" in
         seq [
-          exec ["rm"; "-f"; stdout; stderr; return_value];
+          exec ["rm"; "-f"; stdout; stderr; return_value_path];
           write_output
-            ~stdout ~stderr ~return_value
+            ~stdout ~stderr ~return_value:return_value_path
             (seq [
                 printf "%s" will_be_escaped;
                 printf "%s" will_not_be_escaped;
                 exec ["bash"; "-c"; "printf \"err\\t\\n\" 1>&2"];
-                return 11;
+                return return_value_value;
               ]);
           if_then_else (
             output_as_string (exec ["cat"; stdout])
@@ -91,7 +92,8 @@ let tests =
                 (output_as_string (exec ["cat"; stderr]) <$> string "err")
                 (
                   if_then_else
-                    (output_as_string (exec ["cat"; return_value]) =$= string "11\n")
+                    (output_as_string (exec ["cat"; return_value_path])
+                     =$= ksprintf string "%d\n" return_value_value)
                     (return 11)
                     (return 22)
                 )
@@ -108,7 +110,7 @@ let tests =
           (return 11)
           (return 12)
       );
-    exits 0 Construct.(
+    exits 11 Construct.(
         if_then_else (
           string "some" =$= 
           (output_as_string (
@@ -117,7 +119,7 @@ let tests =
                  (printf "some"))
             ))
         )
-          (return 0)
+          (return 11)
           (return 12)
       );
     exits 10 Construct.(


### PR DESCRIPTION
--------------------------------------------------------------------------------


### All Tests

Summary:

* Test "dash" (`'dash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.52 s.
    - version: `"Version: 0.5.8-2.1ubuntu2"`.
* Test "bash" (`'bash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.59 s.
    - version: `"GNU bash, version 4.3.46(1)-release (x86_64-pc-linux-gnu)"`.
* Test "sh" (`'sh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.49 s.
    - version: `""`.
* Test "busybox" (`'busybox' 'ash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.46 s.
    - version: `"BusyBox v1.22.1 (Ubuntu 1:1.22.0-15ubuntu1) multi-call binary."`.
* Test "ksh" (`'ksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 12 / 71 failures
    - time: 0.85 s.
    - version: `"version         sh (AT&T Research) 93u+ 2012-08-01"`.
    - Cf. `/tmp/genspio-test-ksh-failures.txt`.
* Test "mksh" (`'mksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.53 s.
    - version: `"Version: 52c-2"`.
* Test "posh" (`'posh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.58 s.
    - version: `"Version: 0.12.6"`.
* Test "zsh" (`'zsh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
    - 0 / 71 failures
    - time: 0.73 s.
    - version: `"zsh 5.1.1 (x86_64-ubuntu-linux-gnu)"`.

All “known” shells were tested ☺


--------------------------------------------------------------------------------

