### PR TITLE
Improve testing

### DIFF
--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -25,10 +25,11 @@ let check_command s ~verifies =
           then (true, "exited well") :: prev
           else (
             false,
-            sprintf "%s:\nout:\n%s\nerr:\n%s"
+            sprintf "%s:\nout:\n%s\nerr:\n%s\ncall:\n%s\n"
               (Pvem_lwt_unix.System.Shell.status_to_string exit_status)
               out
               err
+              s
           ) :: prev
         in
         return l)

--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -102,10 +102,10 @@ let avaialable_shells () =
   >>= fun l ->
   return (l, !forgotten)
 
-let run ~important_shells l =
+let run ~important_shells ~additional_shells l =
   avaialable_shells ()
   >>= fun (shells, forgotten) ->
-  Pvem_lwt_unix.Deferred_list.while_sequential shells
+  Pvem_lwt_unix.Deferred_list.while_sequential (shells @ additional_shells)
     ~f:begin fun (shell, version) ->
       let start = Unix.gettimeofday () in
       run_with_shell ~shell:shell.command l

--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -3,7 +3,17 @@ open Nonstd
 module String = Sosa.Native_string
 open Pvem_lwt_unix.Deferred_result
 
+let verbose =
+  try Sys.getenv "verbose_tests" = "true" with _ -> false
+
+let babble fmt =
+  ksprintf (fun s ->
+      if verbose
+      then eprintf "%s\n%!" s
+      else ()) fmt
+
 let check_command s ~verifies =
+  babble "check_command\n  %s\n%!" (String.sub s ~index:0 ~length:100 |> Option.value ~default:s);
   Pvem_lwt_unix.System.Shell.execute s
   >>= fun (out, err, exit_status) ->
   List.fold verifies ~init:(return []) ~f:(fun prev_m v ->

--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -92,8 +92,7 @@ let avaialable_shells () =
   >>= fun l ->
   return (l, !forgotten)
 
-let run l =
-  let important_shells = ["bash"; "dash"] in
+let run ~important_shells l =
   avaialable_shells ()
   >>= fun (shells, forgotten) ->
   Pvem_lwt_unix.Deferred_list.while_sequential shells

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -16,14 +16,14 @@ let exits ?name ?args n c = [
 let tests =
   let exit n = Construct.exec ["exit"; Int.to_string n] in
   let return n =
-    Construct.exec ["bash"; "-c"; sprintf "exit %d" n] in
+    Construct.exec ["sh"; "-c"; sprintf "exit %d" n] in
   List.concat [
     exits 0 (Compile.Exec ["ls"]);
     exits 0 Construct.(
         succeeds (exec ["ls"])
         &&& returns ~value:18 (seq [
             exec ["ls"];
-            exec ["bash"; "-c"; "exit 18"]])
+            exec ["sh"; "-c"; "exit 18"]])
       );
     exits 23 Construct.(
         seq [
@@ -80,7 +80,7 @@ let tests =
             (seq [
                 printf "%s" will_be_escaped;
                 printf "%s" will_not_be_escaped;
-                exec ["bash"; "-c"; "printf \"err\\t\\n\" 1>&2"];
+                exec ["sh"; "-c"; "printf \"err\\t\\n\" 1>&2"];
                 return return_value_value;
               ]);
           if_then_else (
@@ -143,7 +143,7 @@ let tests =
           loop_while
             (cat_potentially_empty |> output_as_string <$> string "nnnn")
             ~body:begin
-              exec ["bash"; "-c"; sprintf "printf n >> %s" tmp];
+              exec ["sh"; "-c"; sprintf "printf n >> %s" tmp];
             end;
           return 10;
         ];

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -279,7 +279,10 @@ let () =
     posix_sh_tests
     @ tests
   in
-  begin match Lwt_main.run (Test.run tests) with
+  let important_shells =
+    try Sys.getenv "important_shells" |> String.split ~on:(`Character ',')
+    with _ -> ["bash"; "dash"] in
+  begin match Lwt_main.run (Test.run ~important_shells tests) with
   | `Ok (`Succeeded) -> printf "Success! \\o/.\n%!"; exit 0
   | `Ok (`Failed msg) -> printf "Test failed: %s.\n%!" msg; exit 5
   | `Error (`IO _ as e) ->

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -293,11 +293,17 @@ let () =
           | name :: "escape" :: cmd_arg :: cmd_format :: [] ->
             Test.make_shell name
               ~command:(fun c args ->
+                  let fun_name = "askjdeidjiedjjjdjekjdeijjjidejdejlksi" in
                   let sep =
-                    List.map ~f:Filename.quote (c :: args)
-                    |> String.concat ~sep:" " in
+                    String.concat ~sep:" " (
+                      [fun_name; "() {"; c ; " ; } ; "; fun_name ]
+                      @ List.map ~f:Filename.quote args
+                    )
+                    |> Filename.quote
+                  in
                   String.split cmd_format ~on:(`String cmd_arg)
-                  |> String.concat ~sep)
+                  |> String.concat ~sep
+                )
               ~get_version:"", "Command-line"
           | other ->
             failwith "Nope"

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -11,6 +11,8 @@ travis_install_on_linux () {
 
     export opam_init_options="--comp=$OCAML_VERSION"
     sudo apt-get install -qq  opam time git
+
+    export important_shells=bash,dash,busybox
 }
 
 travis_install_on_osx () {
@@ -28,6 +30,7 @@ travis_install_on_osx () {
     # the tests require more than the default limit
     ulimit -n 2048
 
+    export important_shells=bash,dash
 }
 
 


### PR DESCRIPTION
This allowed me to easily run the tests (more accurately the compiled output of
the tests) on a fresh FreeBSD box on Google-cloud.

```shell
export verbose_tests=true
export important_shells=bash,dash,busybox
export add_shells='
GCloud-freebsd-sh, escape, <cmd>,
    gcloud compute ssh smfbsdbox -- "/bin/sh -c <cmd>"
++
GCloud-freebsd-tcsh, escape, <cmd>,
    gcloud compute ssh smfbsdbox -- "/bin/tcsh -c <cmd>"
'
make && ./genspio-test.byte
```

The results don't seem that nice:

* Test "GCloud-freebsd-sh" (`gcloud compute ssh smfbsdbox -- "/bin/sh -c '<command>' '<arg1>' '<arg2>' '<arg-n>'"`):
    - 56 / 71 failures
    - time: 40.11 s.
    - version: `"Command-line"`.
    - Cf. `/tmp/genspio-test-GCloud-freebsd-sh-failures.txt`.
* Test "GCloud-freebsd-tcsh" (`gcloud compute ssh smfbsdbox -- "/bin/tcsh -c '<command>' '<arg1>' '<arg2>' '<arg-n>'"`):
    - 68 / 71 failures
    - time: 39.16 s.
    - version: `"Command-line"`.
    - Cf. `/tmp/genspio-test-GCloud-freebsd-tcsh-failures.txt`.

`tcsh` is not POSIX at all, errors look like:

```
export: Command not found.
trap: Command not found.
{: Command not found.
}: Command not found.
}: Command not found.
}: Command not found.
```

I'll investigate further the `/bin/sh` problems but some of them are just that
the test itself uses `bash` directly, but other test results look scarier:

```
/bin/sh: 1: Syntax error: Unterminated quoted string
```
