### PR TITLE
Fix how `output_as_string` deals with “failures”

### DIFF
--- a/src/lib/language.ml
+++ b/src/lib/language.ml
@@ -208,8 +208,7 @@ let rec to_shell: type a. _ -> a t -> string =
     | Literal lit ->
       Literal.to_shell lit
     | Output_as_string e ->
-      sprintf "\"$( { %s || %s ; }  | od -t o1 -An -v | tr -d ' \\n' )\""
-        (continue e) params.die_command
+      sprintf "\"$( { %s ; } | od -t o1 -An -v | tr -d ' \\n' )\"" (continue e)
     | Feed (string, e) ->
       sprintf {sh|  %s | %s  |sh}
         (continue string |> expand_octal) (continue e)


### PR DESCRIPTION
`output_as_string` now does not kill the script if the command fails;
this gives more power to the user who can still implement the previous
behavior easily.

Cf. the tests:

```ocaml
exits 77 Construct.(
    let tmp = "/tmp/test_error_in_output_as_string" in
    let cat_tmp = exec ["cat"; tmp] in
    let succeed_or_die ut =
      if_then_else (succeeds ut)
        nop
        (seq [
            printf "Failure !";
            fail;
          ]) in
    seq [
      exec ["rm"; "-f"; tmp];
      if_then_else
        (seq [printf "aaa"; cat_tmp] |> succeed_or_die
         |> output_as_string =$= string "aaa")
        (return 11)
        (return 12);
    ];
  );
```