### PR TITLE
Add `EDSL.with_redirections`

### DIFF
--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -2,6 +2,7 @@ type 'a t = 'a Language.t
 type 'a cli_option = 'a Language.cli_option
 type 'a option_spec = 'a Language.option_spec
 type ('a, 'b) cli_options = ('a, 'b) Language.cli_options
+type fd_redirection = Language.fd_redirection
 let (//) = Filename.concat
 
 include Language.Construct

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -127,6 +127,12 @@ val make_switch :
 (**/**)
 
 
+type fd_redirection
+val to_fd: int t -> int t -> fd_redirection
+val to_file: int t -> string t -> fd_redirection
+val with_redirections:
+  unit t -> fd_redirection list -> unit t
+
 val write_output :
   ?stdout:string t ->
   ?stderr:string t ->

--- a/src/lib/common.ml
+++ b/src/lib/common.ml
@@ -11,6 +11,7 @@ module Unique_name = struct
       prefix
       !x
       (Random.int 100_000)
+  let variable = create
 
 end
 

--- a/src/lib/language.ml
+++ b/src/lib/language.ml
@@ -231,7 +231,7 @@ let rec to_shell: type a. _ -> a t -> string =
         ksprintf failwith "to_shell: sorry literal %S is impossible to \
                            escape as `exec` argument" s
       | `String v ->
-        let variable_name = Unique_name.create varprefix in
+        let variable_name = Unique_name.variable varprefix in
         let declaration =
           sprintf "%s=$(%s; printf 'x')"
             variable_name (continue v |> expand_octal)
@@ -240,7 +240,7 @@ let rec to_shell: type a. _ -> a t -> string =
           (sprintf "\"${%s%%?}\"" variable_name)
       | `Int (Literal (Literal.Int s)) -> argument (Int.to_string s)
       | `Int other ->
-        let variable_name = Unique_name.create varprefix in
+        let variable_name = Unique_name.variable varprefix in
         let declaration = sprintf "%s=%s" variable_name (continue other) in
         argument ~variable_name ~declaration
           (sprintf "\"${%s%%?}\"" variable_name) 
@@ -408,7 +408,7 @@ let rec to_shell: type a. _ -> a t -> string =
         ])
     | Fail -> die "EDSL.fail called"
     | Parse_command_line { options; action } ->
-      let prefix = Unique_name.create "getopts" in
+      let prefix = Unique_name.variable "getopts" in
       let variable {switch; doc;} =
         sprintf "%s_%c" prefix switch in
       let inits = ref [] in


### PR DESCRIPTION
The construct `EDSL.write_output` uses `EDSL.with_redirections` now.