### PR TITLE
Revamp CLI parsing + bunch of “side effects”

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Tests can be tweaked with environment variables:
 - `add_shells`: is a `++`-separated list of “shells,” each one defined as a
   comma-separated list: `<Name>,escape, <cmd-arg>, <cmd>`, where is
   `<cmd-arg>` is replaced with the actual command tested within `<cmd>`, e.g.:
+- `only_dash`: run the tests only with `dash` (useful to speedup
+  modify-compile-test loops while developing).
 
 ```
 export add_shells='

--- a/README.md
+++ b/README.md
@@ -54,39 +54,39 @@ cf. [`#35`](https://github.com/hammerlab/genspio/issues/35)):
 Summary:
 
 * Test "dash" (`'dash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 0 / 141 failures
-    - time: 2.46 s.
+    - 0 / 184 failures
+    - time: 16.04 s.
     - version: `"Version: 0.5.8-2.1ubuntu2"`.
 * Test "bash" (`'bash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 0 / 141 failures
-    - time: 4.47 s.
+    - 0 / 184 failures
+    - time: 28.24 s.
     - version: `"GNU bash, version 4.3.46(1)-release (x86_64-pc-linux-gnu)"`.
 * Test "sh" (`'sh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 0 / 141 failures
-    - time: 2.73 s.
+    - 0 / 184 failures
+    - time: 15.69 s.
     - version: `""`.
 * Test "busybox" (`'busybox' 'ash' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 0 / 141 failures
-    - time: 1.87 s.
+    - 0 / 184 failures
+    - time: 11.43 s.
     - version: `"BusyBox v1.22.1 (Ubuntu 1:1.22.0-15ubuntu1) multi-call binary."`.
 * Test "ksh" (`'ksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 27 / 141 failures
-    - time: 3.28 s.
+    - 19 / 184 failures
+    - time: 20.85 s.
     - version: `"version         sh (AT&T Research) 93u+ 2012-08-01"`.
     - Cf. `/tmp/genspio-test-ksh-failures.txt`.
 * Test "mksh" (`'mksh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 2 / 141 failures
-    - time: 4.40 s.
+    - 2 / 184 failures
+    - time: 29.24 s.
     - version: `"Version: 52c-2"`.
     - Cf. `/tmp/genspio-test-mksh-failures.txt`.
 * Test "posh" (`'posh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 2 / 141 failures
-    - time: 4.21 s.
+    - 2 / 184 failures
+    - time: 29.13 s.
     - version: `"Version: 0.12.6"`.
     - Cf. `/tmp/genspio-test-posh-failures.txt`.
 * Test "zsh" (`'zsh' '-x' '-c' '<command>' '--' '<arg1>' '<arg2>' '<arg-n>'`):
-    - 4 / 141 failures
-    - time: 4.79 s.
+    - 20 / 184 failures
+    - time: 22.33 s.
     - version: `"zsh 5.1.1 (x86_64-ubuntu-linux-gnu)"`.
     - Cf. `/tmp/genspio-test-zsh-failures.txt`.
 

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -21,7 +21,7 @@ let switch l =
   make_switch ~default:(Option.value ~default:nop !default) cases
 
 let string_concat sl =
-  concat (list sl)
+  string_concat_list (list sl)
 
 type file = <
   get : string t;

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -111,3 +111,222 @@ let if_seq ~t ?e c =
   match e with
   | None -> if_then c (seq t)
   | Some f -> if_then_else c (seq t) (seq f) 
+
+
+let eprintf fmt l =
+  with_redirections
+    (call (string "printf" :: string "--" :: fmt :: l)) [
+    to_fd (int 1) (int 2);
+  ]
+
+module Command_line = struct
+  type 'a cli_option = {
+    switches: string list;
+    doc: string;
+    default: 'a;
+  }
+  type _ option_spec =
+    | Opt_flag:   bool t cli_option -> bool t option_spec
+    | Opt_string: string t cli_option -> string t option_spec
+  and (_, _) cli_options =
+    | Opt_end: string -> ('a, 'a) cli_options
+    | Opt_cons: 'c option_spec * ('a, 'b) cli_options -> ('c -> 'a, 'b) cli_options
+
+  module Arg = struct
+    let string ?(default = string "") ~doc switches =
+      Opt_string {switches; doc; default}
+    let flag ?(default = bool false) ~doc switches =
+      Opt_flag {switches; doc; default}
+
+    let (&) x y = Opt_cons (x, y)
+    let usage s = Opt_end s
+
+  end
+
+  let parse
+      (options: ('a, unit t) cli_options)
+      (action: 'a) : unit t =
+    let prefix = Common.Unique_name.variable "getopts" in
+    let variable {switches; doc;} =
+      sprintf "%s_%s" prefix (String.concat ~sep:"" switches|> Digest.string |> Digest.to_hex) in
+    let inits = ref [] in
+    let to_init s = inits := s :: !inits in
+    let cases = ref [] in
+    let to_case s = cases := s :: !cases in
+    let help_intro = ref "" in
+    let help = ref [] in
+    let to_help s = help := s :: !help in
+    let string_of_var var =
+      getenv (string var) in
+    (* Output_as_string (Raw_cmd (sprintf "printf \"${%s}\"" var)) in *)
+    let bool_of_var var =
+      succeeds (Language.Raw_cmd (sprintf "{ ${%s} ; } " var)) in
+    let unit_t =
+      let rec loop
+        : type a b.
+          a -> (a, b) cli_options -> b =
+        fun f -> function
+        | Opt_end doc ->
+          help_intro := doc;
+          f
+        | Opt_cons (Opt_string x, more) ->
+          let var = variable x in
+          to_init (
+            setenv (string var) x.default);
+          (* sprintf "export %s=$(%s)" *)
+          (*          var (continue x.default |> expand_octal)); *)
+          to_case (
+            case (List.fold ~init:(bool false) x.switches ~f:(fun p s ->
+                p ||| (string s =$= getenv (string "1"))))
+              [
+                if_seq (getenv (string "2") =$= string "")
+                  ~t:[
+                    eprintf
+                      (string "ERROR option '%s' requires an argument\\n")
+                      [getenv (string "1")];
+                    fail;
+                  ]
+                  ~e:[
+                    setenv (string var) (getenv (string "2"));
+                  ];
+                exec ["shift"];
+                exec ["shift"];
+              ]
+          );
+          (* (seq  *)
+          (*      "if [ -n \"$2\" ]"; *)
+          (*      sprintf "then export %s=\"$2\" " var; *)
+          (*      sprintf "else printf \"ERROR -%c requires an argument\\n\" \ *)
+                  (*               >&2" x.switch; *)
+          (*      die "Command line parsing error: Aborting"; *)
+          (*      "fi"; *)
+          (*      "shift"; *)
+          (*      "shift"; *)
+          (*    ])); *)
+          ksprintf to_help "* `%s <string>`: %s"
+            (String.concat ~sep:"," x.switches) x.doc;
+          loop (f (string_of_var var)) more
+        | Opt_cons (Opt_flag x, more) ->
+          let var = variable x in
+          to_init (
+            if_then_else x.default
+              (setenv (string var) (string "true"))
+              (setenv (string var) (string "false"))
+          );
+          (* sprintf *)
+          (*          "export %s=$(if %s ; then printf 'true' ; else printf 'false' ; fi)" var *)
+          (*          (continue x.default)); *)
+          to_case (
+            case (List.fold ~init:(bool false) x.switches ~f:(fun p s ->
+                p ||| (string s =$= getenv (string "1"))))
+              [
+                setenv (string var) (string "true");
+                exec ["shift"];
+              ]
+              (* sprintf "-%c) %s ;;" *)
+              (*   x.switch (seq [ *)
+              (*       sprintf "export %s=true" var; *)
+              (*       "shift"; *)
+              (*     ]) *)
+          );
+          ksprintf to_help "* `%s`: %s"
+            (String.concat ~sep:"," x.switches) x.doc;
+          (* ksprintf to_help "* `-%c`: %s" x.switch x.doc; *)
+          loop (f (bool_of_var var)) more
+      in
+      loop action options
+    in
+    let help_msg =
+      sprintf "%s\n\nOptions:\n\n%s\n"
+        !help_intro (String.concat ~sep:"\n" (List.rev !help))
+    in
+    let help_flag_var = ksprintf string "%s_help" prefix in
+    let while_loop =
+      let body =
+        let help_case =
+          let help_switches = ["-h"; "-help"; "--help"] in
+          case
+            (List.fold ~init:(bool false) help_switches ~f:(fun p s ->
+                 p ||| (string s =$= getenv (string "1")))) [
+            setenv help_flag_var (string "true");
+            string help_msg >>  exec ["cat"];
+            exec ["break"];
+          ]
+        in
+        let dash_dash_case =
+          case (getenv (string "1") =$= string "--") [
+            eprintf (string "WARNING: dash-dash arg: %s\\n") [getenv (string "1")];
+            exec ["shift"];
+            exec ["break"];
+          ] in
+        let anon_case =
+          case (getenv (string "#") <$> string "0") [
+            eprintf (string "WARNING: annon arg: %s\\n") [getenv (string "1")];
+            exec ["shift"];
+          ] in
+        let default_case =
+          default [
+            eprintf (string "WARNING: should be empty: '%s'\\n") [getenv (string "1")];
+            exec ["break"];
+          ] in
+        let cases =
+          help_case :: List.rev !cases @ [dash_dash_case; anon_case; default_case] in
+        seq [
+          eprintf (string "While loop start: $1: %s\n") [getenv (string "1")];
+          switch cases;
+          eprintf (string "While loop end: $1: %s\n") [getenv (string "1")];
+        ] in
+      loop_while (bool true) ~body
+    in
+    (*   let sep = if params.statement_separator = " \n " then "\n" else " " in *)
+    (*   String.concat ~sep ( *)
+    (*     [ *)
+    (*       "while :;"; " do case $1 in"; *)
+    (*       "-h|-help|--help) "; *)
+    (*       sprintf "export %s_help=true ; " prefix; *)
+    (*       sprintf "%s ;" *)
+    (*         (continue Construct.(string help_msg *)
+    (*                              >>  exec ["cat"])); *)
+    (*       " break ;;" *)
+    (*     ] *)
+    (*     @ List.rev !cases *)
+    (*     @ [ *)
+    (*       "--) shift ; break ;;"; *)
+    (*       "-?*\)"; *)
+    (*       "printf 'ERROR: Unknown option: %s\\n' \"$1\" >&2 ;"; *)
+    (*       die "Command line parsing error: Aborting"; *)
+    (*       ";;"; *)
+    (*       "*\) if [ $# -eq 0 ] ; "; *)
+    (*       "then echo \" $1 $# \" ; break ;"; *)
+    (*       sprintf *)
+    (*         " else export %s_args=\"${%s_args} %s\" ; shift ; " *)
+    (*         prefix prefix *)
+    (*         (continue (Output_as_string (Raw_cmd "printf \"$1\""))) ; *)
+    (*       "fi ;; "; *)
+    (*       "esac;"; *)
+    (*       "done"] *)
+    (*   ) *)
+    (* in *)
+    seq [
+      setenv help_flag_var (string "false");
+      seq (List.rev !inits);
+      while_loop;
+      if_then_else (bool_of_var (sprintf "%s_help" prefix))
+        (nop)
+        unit_t;
+    ]
+(*
+seq (
+  sprintf "export %s_args=" prefix
+  :: sprintf "export %s_help=false" prefix
+  :: List.rev !inits @ [
+    while_loop;
+    continue Construct.(
+        if_then_else (bool_of_var (sprintf "%s_help" prefix))
+          (nop)
+          unit_t);
+  ])
+  assert false
+*)
+
+end

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -21,9 +21,7 @@ let switch l =
   make_switch ~default:(Option.value ~default:nop !default) cases
 
 let string_concat sl =
-  (* This is a pretty unefficient implementation: *)
-  let out s = call [string "printf"; string "%s"; s] in
-  seq (List.map sl ~f:out) |> output_as_string
+  concat (list sl)
 
 type file = <
   get : string t;

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -1,7 +1,4 @@
 type 'a t = 'a Language.t
-type 'a cli_option = 'a Language.cli_option
-type 'a option_spec = 'a Language.option_spec
-type ('a, 'b) cli_options = ('a, 'b) Language.cli_options
 type fd_redirection = Language.fd_redirection
 let (//) = Filename.concat
 

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -158,7 +158,6 @@ module Command_line = struct
     let to_help s = help := s :: !help in
     let string_of_var var =
       getenv (string var) in
-    (* Output_as_string (Raw_cmd (sprintf "printf \"${%s}\"" var)) in *)
     let bool_of_var var =
       succeeds (Language.Raw_cmd (sprintf "{ ${%s} ; } " var)) in
     let unit_t =
@@ -173,8 +172,6 @@ module Command_line = struct
           let var = variable x in
           to_init (
             setenv (string var) x.default);
-          (* sprintf "export %s=$(%s)" *)
-          (*          var (continue x.default |> expand_octal)); *)
           to_case (
             case (List.fold ~init:(bool false) x.switches ~f:(fun p s ->
                 p ||| (string s =$= getenv (string "1"))))
@@ -193,16 +190,6 @@ module Command_line = struct
                 exec ["shift"];
               ]
           );
-          (* (seq  *)
-          (*      "if [ -n \"$2\" ]"; *)
-          (*      sprintf "then export %s=\"$2\" " var; *)
-          (*      sprintf "else printf \"ERROR -%c requires an argument\\n\" \ *)
-                  (*               >&2" x.switch; *)
-          (*      die "Command line parsing error: Aborting"; *)
-          (*      "fi"; *)
-          (*      "shift"; *)
-          (*      "shift"; *)
-          (*    ])); *)
           ksprintf to_help "* `%s <string>`: %s"
             (String.concat ~sep:"," x.switches) x.doc;
           loop (f (string_of_var var)) more
@@ -213,9 +200,6 @@ module Command_line = struct
               (setenv (string var) (string "true"))
               (setenv (string var) (string "false"))
           );
-          (* sprintf *)
-          (*          "export %s=$(if %s ; then printf 'true' ; else printf 'false' ; fi)" var *)
-          (*          (continue x.default)); *)
           to_case (
             case (List.fold ~init:(bool false) x.switches ~f:(fun p s ->
                 p ||| (string s =$= getenv (string "1"))))
@@ -223,15 +207,9 @@ module Command_line = struct
                 setenv (string var) (string "true");
                 exec ["shift"];
               ]
-              (* sprintf "-%c) %s ;;" *)
-              (*   x.switch (seq [ *)
-              (*       sprintf "export %s=true" var; *)
-              (*       "shift"; *)
-              (*     ]) *)
           );
           ksprintf to_help "* `%s`: %s"
             (String.concat ~sep:"," x.switches) x.doc;
-          (* ksprintf to_help "* `-%c`: %s" x.switch x.doc; *)
           loop (f (bool_of_var var)) more
       in
       loop action options
@@ -278,35 +256,6 @@ module Command_line = struct
         ] in
       loop_while (bool true) ~body
     in
-    (*   let sep = if params.statement_separator = " \n " then "\n" else " " in *)
-    (*   String.concat ~sep ( *)
-    (*     [ *)
-    (*       "while :;"; " do case $1 in"; *)
-    (*       "-h|-help|--help) "; *)
-    (*       sprintf "export %s_help=true ; " prefix; *)
-    (*       sprintf "%s ;" *)
-    (*         (continue Construct.(string help_msg *)
-    (*                              >>  exec ["cat"])); *)
-    (*       " break ;;" *)
-    (*     ] *)
-    (*     @ List.rev !cases *)
-    (*     @ [ *)
-    (*       "--) shift ; break ;;"; *)
-    (*       "-?*\)"; *)
-    (*       "printf 'ERROR: Unknown option: %s\\n' \"$1\" >&2 ;"; *)
-    (*       die "Command line parsing error: Aborting"; *)
-    (*       ";;"; *)
-    (*       "*\) if [ $# -eq 0 ] ; "; *)
-    (*       "then echo \" $1 $# \" ; break ;"; *)
-    (*       sprintf *)
-    (*         " else export %s_args=\"${%s_args} %s\" ; shift ; " *)
-    (*         prefix prefix *)
-    (*         (continue (Output_as_string (Raw_cmd "printf \"$1\""))) ; *)
-    (*       "fi ;; "; *)
-    (*       "esac;"; *)
-    (*       "done"] *)
-    (*   ) *)
-    (* in *)
     seq [
       setenv help_flag_var (string "false");
       seq (List.rev !inits);
@@ -315,18 +264,5 @@ module Command_line = struct
         (nop)
         unit_t;
     ]
-(*
-seq (
-  sprintf "export %s_args=" prefix
-  :: sprintf "export %s_help=false" prefix
-  :: List.rev !inits @ [
-    while_loop;
-    continue Construct.(
-        if_then_else (bool_of_var (sprintf "%s_help" prefix))
-          (nop)
-          unit_t);
-  ])
-  assert false
-*)
 
 end

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -268,28 +268,6 @@ val tmp_file: ?tmp_dir: string t -> string -> file
 
 (** {3 Command Line Parsing} *)
 
-type 'argument_type cli_option = 'argument_type Language.cli_option
-type 'argument_type option_spec = 'argument_type Language.option_spec
-type ('parse_function, 'return_type) cli_options = ('parse_function, 'return_type) Language.cli_options
-module Option_list : sig
-  val string :
-    ?default: string t ->
-    doc:string -> char ->
-    string t option_spec
-  val flag :
-    ?default: bool t ->
-    doc:string -> char ->
-    bool t option_spec
-  val ( & ) :
-    'argument_type option_spec ->
-    ('parse_function, 'return_type) cli_options ->
-    ('argument_type -> 'parse_function, 'return_type) cli_options
-  val usage : string -> ('last_return_type, 'last_return_type) cli_options
-end
-
-val parse_command_line :
-  ('parse_function, unit t) cli_options -> 'parse_function -> unit t
-
 module Command_line: sig
 
   type 'a cli_option = {

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -200,6 +200,8 @@ val write_output :
 
 val write_stdout : path: string t -> unit t -> unit t
 
+val eprintf : string t -> string t list -> unit t
+
 (** {3 Escaping The Execution Flow } *)
 
 val fail: unit t
@@ -287,6 +289,38 @@ end
 
 val parse_command_line :
   ('parse_function, unit t) cli_options -> 'parse_function -> unit t
+
+module Command_line: sig
+
+  type 'a cli_option = {
+    switches : string list;
+    doc : string;
+    default : 'a;
+  }
+
+  type _ option_spec =
+      Opt_flag : bool t cli_option -> bool t option_spec
+    | Opt_string : string t cli_option -> string t option_spec
+  and (_, _) cli_options =
+      Opt_end : string -> ('a, 'a) cli_options
+    | Opt_cons : 'c option_spec *
+        ('a, 'b) cli_options -> ('c -> 'a, 'b) cli_options
+  module Arg :
+    sig
+      val string :
+        ?default:string t ->
+        doc:string -> string list -> string t option_spec
+      val flag :
+        ?default:bool t -> doc:string -> string list -> bool t option_spec
+      val ( & ) :
+        'a option_spec -> ('b, 'c) cli_options -> ('a -> 'b, 'c) cli_options
+      val usage : string -> ('a, 'a) cli_options
+    end
+  val parse : ('a, unit t) cli_options -> 'a -> unit t
+end
+
+
+
 
 (** {3 Very Unsafe Operations} *)
 

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -107,9 +107,10 @@ val list: 'a t list -> 'a list t
 val output_as_string : unit t -> string t
 val feed : string:string t -> unit t -> unit t
 val ( >> ) : string t -> unit t -> unit t
+
 val string_concat: string t list -> string t
 
-val concat : string list t -> string t
+val string_concat_list: string list t -> string t
 
 (** {3 Control Flow} *)
 

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -104,6 +104,8 @@ val list: 'a t list -> 'a list t
 
 val list_append: 'a list t -> 'a list t -> 'a list t
 
+val list_iter: 'a list t -> f:((unit -> 'a t) -> unit t) -> unit t
+
 
 (** {3 String Manipulation} *)
 

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -52,6 +52,12 @@ val ( =$= ) : string t -> string t -> bool t
 val ( <$> ) : string t -> string t -> bool t
 
 val returns: 'a t -> value: int -> bool t
+
+module Bool: sig
+  val to_string : bool t -> string t
+  val of_string : string t -> bool t
+end
+
 (** Check the return value of a command/expression/script. *)
     
 val succeeds : 'a t -> bool t

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -102,6 +102,9 @@ end
 
 val list: 'a t list -> 'a list t
 
+val list_append: 'a list t -> 'a list t -> 'a list t
+
+
 (** {3 String Manipulation} *)
 
 val output_as_string : unit t -> string t

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -98,12 +98,18 @@ module Integer : sig
   val ( > ) : int t -> int t -> bool t
 end
 
+(** {3 Lists} *)
+
+val list: 'a t list -> 'a list t
+
 (** {3 String Manipulation} *)
 
 val output_as_string : unit t -> string t
 val feed : string:string t -> unit t -> unit t
 val ( >> ) : string t -> unit t -> unit t
 val string_concat: string t list -> string t
+
+val concat : string list t -> string t
 
 (** {3 Control Flow} *)
 

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -314,7 +314,7 @@ module Command_line: sig
         'a option_spec -> ('b, 'c) cli_options -> ('a -> 'b, 'c) cli_options
       val usage : string -> ('a, 'a) cli_options
     end
-  val parse : ('a, unit t) cli_options -> 'a -> unit t
+  val parse : ('a, unit t) cli_options -> (anon: string list t -> 'a) -> unit t
 end
 
 

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -106,6 +106,8 @@ val list_append: 'a list t -> 'a list t -> 'a list t
 
 val list_iter: 'a list t -> f:((unit -> 'a t) -> unit t) -> unit t
 
+val list_to_string: 'a list t -> f:('a t -> string t) -> string t
+val list_of_string: string t -> f:(string t -> 'a t) -> 'a list t
 
 (** {3 String Manipulation} *)
 

--- a/src/lib/language.ml
+++ b/src/lib/language.ml
@@ -64,6 +64,7 @@ and _ t =
   | String_to_bool: string t -> bool t
   | List: 'a t list -> 'a list t
   | String_concat: string list t -> string t
+  | List_append: ('a list t * 'a list t) -> 'a list t
   | Int_bin_op:
       int t * [ `Plus | `Minus | `Mult | `Div | `Mod ] * int t -> int t
   | Int_bin_comparison:
@@ -136,6 +137,8 @@ module Construct = struct
   let list l = List l
 
   let string_concat_list l = String_concat l
+
+  let list_append la lb = List_append (la, lb)
 
   module Bool = struct
     let of_string s = String_to_bool s
@@ -374,6 +377,8 @@ let rec to_shell: type a. _ -> a t -> string =
     | String_concat sl ->
       let outputing_list = continue sl in
       sprintf "$( { %s ; } | tr -d '\\n' )" outputing_list
+    | List_append (la, lb) ->
+      seq (continue la :: "printf -- '\\n'" :: continue lb :: [])
     | Int_bin_op (ia, op, ib) ->
       sprintf "$(( %s %s %s ))"
         (continue ia)

--- a/src/lib/language.ml
+++ b/src/lib/language.ml
@@ -11,11 +11,9 @@ module Literal = struct
     | Int i -> sprintf "%d" i
     | String s ->
       with_buffer begin fun str ->
-        str "'";
         String.iter s ~f:(fun c ->
             Char.code c |> sprintf "%03o" |> str
           );
-        str "'"
       end |> fst
     | Bool true -> "true"
     | Bool false -> "false"
@@ -247,7 +245,7 @@ let rec to_shell: type a. _ -> a t -> string =
         (match op with `And -> "&&" | `Or -> "||")
         (continue b)
     | String_operator (a, op, b) ->
-      sprintf "[ %s %s %s ]"
+      sprintf "[ \"%s\" %s \"%s\" ]"
         (continue a)
         (match op with `Eq -> "=" | `Neq -> "!=")
         (continue b)

--- a/src/lib/language.ml
+++ b/src/lib/language.ml
@@ -135,7 +135,7 @@ module Construct = struct
 
   let list l = List l
 
-  let concat l = String_concat l
+  let string_concat_list l = String_concat l
 
   module Bool = struct
     let of_string s = String_to_bool s

--- a/src/test-lib/test_lib.ml
+++ b/src/test-lib/test_lib.ml
@@ -95,13 +95,13 @@ let avaialable_shells () =
     sprintf "dpkg -s %s | grep ^Version" package in
   let candidates = [
     dash_like "dash" ~get_version:(package_version "dash");
-    dash_like "bash" ~get_version:"bash --version | head -n 1";
-    dash_like "sh" ~get_version:(package_version "sh");
+    (* dash_like "bash" ~get_version:"bash --version | head -n 1"; *)
+    (* dash_like "sh" ~get_version:(package_version "sh"); *)
     busybox;
-    dash_like "ksh" ~get_version:"ksh --version 2>&1";
-    dash_like "mksh" ~get_version:(package_version "mksh");
-    dash_like "posh" ~get_version:(package_version "posh");
-    dash_like "zsh" ~get_version:"zsh --version";
+    (* dash_like "ksh" ~get_version:"ksh --version 2>&1"; *)
+    (* dash_like "mksh" ~get_version:(package_version "mksh"); *)
+    (* dash_like "posh" ~get_version:(package_version "posh"); *)
+    (* dash_like "zsh" ~get_version:"zsh --version"; *)
   ] in
   let forgotten = ref [] in
   Pvem_lwt_unix.Deferred_list.while_sequential candidates ~f:(fun sh ->

--- a/src/test/examples.ml
+++ b/src/test/examples.ml
@@ -144,20 +144,21 @@ let downloader () =
   end in
   let no_value = sprintf "none_%x" (Random.int 100_000) |> string in
   let cli_spec =
-    Option_list.(
+    Command_line.Arg.(
       string
-        ~doc:"The URL to the stuff" 'u'
+        ~doc:"The URL to the stuff" ["-u"; "--url"]
         ~default:no_value
-      & flag 'c' ~doc:"Do everything in the temp-dir"
-      & string 'f'
+      & flag ["-c"; "--all-in-tmp"] ~doc:"Do everything in the temp-dir"
+      & string ["-f"; "--local-filename"]
         ~doc:"Override the downloaded file-name"
         ~default:no_value
-      & string 't'
+      & string ["-t"; "--tmp-dir"]
         ~doc:"Use <dir> as temp-dir"
         ~default:(Genspio.EDSL.string "/tmp/genspio-downloader-tmpdir")
-      & usage "$0 -u URL [-c]"
+      & usage "Download archives and decrypt/unarchive them.\n\
+               ./downloader -u URL [-c] [-f <file>] [-t <tmpdir>]"
     ) in
-  parse_command_line cli_spec
+  Command_line.parse cli_spec
     begin fun url all_in_tmp filename_ov tmp_dir ->
       let current_name = tmp_file ~tmp_dir "current-name" in
       let set_output_of_download () =

--- a/src/test/examples.ml
+++ b/src/test/examples.ml
@@ -159,7 +159,7 @@ let downloader () =
                ./downloader -u URL [-c] [-f <file>] [-t <tmpdir>]"
     ) in
   Command_line.parse cli_spec
-    begin fun url all_in_tmp filename_ov tmp_dir ->
+    begin fun ~anon url all_in_tmp filename_ov tmp_dir ->
       let current_name = tmp_file ~tmp_dir "current-name" in
       let set_output_of_download () =
         if_seq (filename_ov =$= no_value)

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -698,6 +698,13 @@ let tests =
           );
       ];
     end;
+    exits ~name:"tmp#basic" 23 Genspio.EDSL.(
+        let tmp = tmp_file "test" in
+        seq [
+          tmp#set (string "");
+          return 23;
+        ]
+      );
     exits ~name:"tmp#delete" 23 Genspio.EDSL.(
         let tmp = tmp_file "test" in
         let s1 = string "hello\000you" in

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -841,6 +841,8 @@ let () =
   let important_shells =
     try Sys.getenv "important_shells" |> String.split ~on:(`Character ',')
     with _ -> ["bash"; "dash"] in
+  let only_dash =
+    try Sys.getenv "only_dash" = "true" with _ -> false in
   let all_tests = posix_sh_tests @ tests in
   let tests =
     if test_filters = [] then all_tests else
@@ -883,7 +885,8 @@ let () =
     end
   in
   begin match
-    Lwt_main.run (Test.run ~important_shells ~additional_shells tests)
+    Lwt_main.run
+      (Test.run ~only_dash ~important_shells ~additional_shells tests)
   with
   | `Ok (`Succeeded) -> printf "Success! \\o/.\n%!"; exit 0
   | `Ok (`Failed msg) -> printf "Test failed: %s.\n%!" msg; exit 5

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -837,6 +837,40 @@ let tests =
           (return 11)
           (return 12)
       );
+    exits 5 ~name:"list-string-stuff" Genspio.EDSL.(
+        seq [
+          assert_or_fail "test1" (
+            (concat (list [string "one"; string "two"; string "three"]))
+            =$= string "onetwothree"
+          );
+          assert_or_fail "test2" (
+            (concat (list [string "one"; string "two"]))
+            =$= string "onetwo"
+          );
+          assert_or_fail "test3" (
+            (concat (list [string "one"]))
+            =$= string "one"
+          );
+          assert_or_fail "test4" (
+            (concat (list []))
+            =$= string ""
+          );
+          assert_or_fail "test5" (
+            (concat (list [string ""]))
+            =$= string ""
+          );
+          assert_or_fail "test6" (
+            (concat (list [string "one"; string ""; string "three"]))
+            =$= string "onethree"
+          );
+          assert_or_fail "test7" (
+            (concat (list [string "one"; string ""; string ""]))
+            =$= string "one"
+          );
+          return 5
+        ]
+      );
+
   ]
 
 let posix_sh_tests = [

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -208,6 +208,17 @@ let tests =
           (return 11)
           (return 12)
       );
+    exits 11 ~name:"output-as-empty-string" Construct.(
+        if_then_else (
+          string "" =$=
+          (output_as_string (exec ["printf"; ""]))
+        )
+          (return 11)
+          (return 12)
+      );
+    exits 11 ~name:"empty-string" Construct.(
+        if_then_else (string "" =$= string "") (return 11) (return 12)
+      );
     exits 10 Construct.(
         if_then_else
           (
@@ -512,7 +523,7 @@ let tests =
         )
           (return 12) (return 27)
       );
-    exits 0 Construct.(
+    exits 0 ~name:"setenv-getenv" Construct.(
         let var = string "VVVVVVV" in
         let assert_or_return ret cond =
           if_then_else cond nop (seq [printf "Fail: %d" ret; fail]) in
@@ -522,9 +533,9 @@ let tests =
           assert_or_return 28 (getenv var =$= string "Bouh");
           (* We also “record the undefined behavior” *)
           setenv ~var (string "Bouhh\nbah");
-          assert_or_return 29 (getenv var =$= string "Bouhh");
+          assert_or_return 29 (getenv var =$= string "Bouhh\nbah");
           setenv ~var (string "Bouhhh\nbah\n");
-          assert_or_return 30 (getenv var =$= string "Bouhhh");
+          assert_or_return 30 (getenv var =$= string "Bouhhh\nbah");
           setenv ~var (string "Bouhoo\000bah\n");
           assert_or_return 12 (getenv var =$= string "Bouhoobah");
           (* We check that the environment is affected in a brutal way:

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -847,31 +847,31 @@ let tests =
     exits 5 ~name:"list-string-stuff" Genspio.EDSL.(
         seq [
           assert_or_fail "test1" (
-            (concat (list [string "one"; string "two"; string "three"]))
+            (string_concat_list (list [string "one"; string "two"; string "three"]))
             =$= string "onetwothree"
           );
           assert_or_fail "test2" (
-            (concat (list [string "one"; string "two"]))
+            (string_concat_list (list [string "one"; string "two"]))
             =$= string "onetwo"
           );
           assert_or_fail "test3" (
-            (concat (list [string "one"]))
+            (string_concat_list (list [string "one"]))
             =$= string "one"
           );
           assert_or_fail "test4" (
-            (concat (list []))
+            (string_concat_list (list []))
             =$= string ""
           );
           assert_or_fail "test5" (
-            (concat (list [string ""]))
+            (string_concat_list (list [string ""]))
             =$= string ""
           );
           assert_or_fail "test6" (
-            (concat (list [string "one"; string ""; string "three"]))
+            (string_concat_list (list [string "one"; string ""; string "three"]))
             =$= string "onethree"
           );
           assert_or_fail "test7" (
-            (concat (list [string "one"; string ""; string ""]))
+            (string_concat_list (list [string "one"; string ""; string ""]))
             =$= string "one"
           );
           return 5

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -804,6 +804,28 @@ let tests =
           return 2
         ]
       );
+    exits 2 ~name:"bool-string-conversions" Genspio.EDSL.(
+        seq [
+          assert_or_fail "test1" (
+            (Bool.to_string (bool true)) =$= string "true"
+          );
+          assert_or_fail "test2" (
+            (Bool.to_string (bool false)) =$= string "false"
+          );
+          assert_or_fail "test3" (
+            (Bool.to_string (bool true) |> Bool.of_string)
+          );
+          assert_or_fail "test4" (
+            (Bool.to_string (bool false) |> Bool.of_string |> not)
+          );
+          return 2
+        ]
+      );
+    exits 77 ~name:"bool-string-wrong-conversions" Genspio.EDSL.(
+        if_then_else (string "anything" |> Bool.of_string |> not)
+          (return 11)
+          (return 12)
+      );
   ]
 
 let posix_sh_tests = [

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -877,7 +877,39 @@ let tests =
           return 5
         ]
       );
-
+    exits 5 ~name:"list-append" Genspio.EDSL.(
+        let make_string_concat_test name la lb =
+          let slist l = List.map l ~f:string |> list in
+          assert_or_fail name (
+            string_concat_list (list_append (slist la) (slist lb))
+            =$=
+            string (la @ lb |> String.concat ~sep:"")
+          );
+        in
+        seq [
+          make_string_concat_test "test1"
+            ["one"; "two"; "three"] [];
+          make_string_concat_test "test2"
+            ["one"; "two"; "three"] ["four"];
+          make_string_concat_test "test3"
+            ["one"; "two"] ["thre"; "four"];
+          make_string_concat_test "test4"
+            [] ["thre"; "four"];
+          make_string_concat_test "test5"
+            [] [];
+          make_string_concat_test "test6"
+            [""] [];
+          make_string_concat_test "test7"
+            [""] [""];
+          make_string_concat_test "test8"
+            [] [""];
+          make_string_concat_test "test9"
+            [] ["deiajd\ndedaeijl"; ""];
+          make_string_concat_test "test10"
+            [] ["deiajd\ndeda\000eijl"; ":"];
+          return 5
+        ]
+      );
   ]
 
 let posix_sh_tests = [


### PR DESCRIPTION
This is fixing  #28 and doing everything needed along the way:

- [x] CLI parsing moved to be “library code” (i.e. not in the Compiler); also
  now uses also `--long-option` names.
- [x] `Bool.{of,to}_string` → to store booleans without knowing their internal rep
- [x] Notion of `'a list t` values with useful functions (`string_concat{,_list}`, `list_append`, `list_iter`).
- [x] Use lists to pass anonymous arguments (and maybe also string-flags?) to the
  CLI parsing function.


