### PR TITLE
Document and clean-up CLI parsing code

### DIFF
--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -162,20 +162,23 @@ module Command_line = struct
     let anon =
       getenv anonarg_var |> string_list_of_string in
     let applied_action =
-      (* 
-        The `loop` function below is building 3 pieces of code at once:
+      (** 
+        The [loop] function below is building 3 pieces of Genspio code at once:
 
-        * variable intializations
-        * individual cases (incl variable assignments) in the `while true { switch { .... } }` loop
-        * the `unit t`, a.k.a. `applied_action`: it calls the user-provided 
-          `action` function on the parsed arguments (building the closure 
-          as the loop goes), the result is a piece of `unit t` code that uses
-          the parsed command line arguments.
-         
-        The 2 first items are agglomerated in the `inits` and `cases`
+        - variable initializations
+        - individual case statements (including variable assignments)
+          that are part of the ["while true { switch { .... } }"] loop 
+          that incrementally interprets each command line argument.
+        - [applied_action] (of type [unit t]) is the
+          the result of applying the [action] function to all the elements of
+          [options] + the list of anonymous arguments.
+          It is hence the (user-provided) code that uses the parsed arguments.
+          The [loop] function builds the closure as the loop goes since
+          [options] is a “difference list”, see also:
+          {{:https://drup.github.io/2016/08/02/difflists/}Drup's blog post}.
+
+        The 2 first items are agglomerated in the [inits] and [cases]
         references.
-         
-        See also: https://drup.github.io/2016/08/02/difflists/
       *)
       let rec loop
         : type a b.

--- a/src/lib/EDSL.ml
+++ b/src/lib/EDSL.ml
@@ -161,7 +161,22 @@ module Command_line = struct
     let anonarg_var = prefix ^ "_anon" |> string in
     let anon =
       getenv anonarg_var |> string_list_of_string in
-    let unit_t =
+    let applied_action =
+      (* 
+        The `loop` function below is building 3 pieces of code at once:
+
+        * variable intializations
+        * individual cases (incl variable assignments) in the `while true { switch { .... } }` loop
+        * the `unit t`, a.k.a. `applied_action`: it calls the user-provided 
+          `action` function on the parsed arguments (building the closure 
+          as the loop goes), the result is a piece of `unit t` code that uses
+          the parsed command line arguments.
+         
+        The 2 first items are agglomerated in the `inits` and `cases`
+        references.
+         
+        See also: https://drup.github.io/2016/08/02/difflists/
+      *)
       let rec loop
         : type a b.
           a -> (a, b) cli_options -> b =
@@ -239,7 +254,6 @@ module Command_line = struct
         in
         let dash_dash_case =
           case (getenv (string "1") =$= string "--") [
-            eprintf (string "WARNING: dash-dash arg: %s\\n") [getenv (string "1")];
             exec ["shift"];
             loop_while (getenv (string "#") <$> string "0") ~body:begin
               seq [
@@ -251,21 +265,17 @@ module Command_line = struct
           ] in
         let anon_case =
           case (getenv (string "#") <$> string "0") [
-            eprintf (string "WARNING: annon arg: %s\\n") [getenv (string "1")];
             append_anon_arg_to_list;
             exec ["shift"];
           ] in
         let default_case =
           default [
-            eprintf (string "WARNING: should be empty: '%s'\\n") [getenv (string "1")];
             exec ["break"];
           ] in
         let cases =
           help_case :: List.rev !cases @ [dash_dash_case; anon_case; default_case] in
         seq [
-          eprintf (string "While loop start: $1: %s\n") [getenv (string "1")];
           switch cases;
-          eprintf (string "While loop end: $1: %s\n") [getenv (string "1")];
         ] in
       loop_while (bool true) ~body
     in
@@ -276,7 +286,7 @@ module Command_line = struct
       while_loop;
       if_then_else (bool_of_var (sprintf "%s_help" prefix))
         (nop)
-        unit_t;
+        applied_action;
     ]
 
 end

--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -297,13 +297,17 @@ module Command_line: sig
      - Build a command-line “format specification” using the {!Arg} module.
      - Call the {!parse} function with an appropriately typed function.
 
-     Example: {[
+     Example:
+     Here is a potential argument specification for a shell script
+     that downloads and unarchives them (see also ["src/test/examples.ml"]).
+     {[
        let cli_spec =
          Command_line.Arg.(
            string
              ~doc:"The URL to the stuff" ["-u"; "--url"]
              ~default:no_value
-           & flag ["-c"; "--all-in-tmp"] ~doc:"Do everything in the temp-dir"
+           & flag ["-d"; "--remove-intermediary-files"]
+               ~doc:"Remove intermediary files."
            & string ["-f"; "--local-filename"]
              ~doc:"Override the downloaded file-name"
              ~default:no_value
@@ -322,7 +326,7 @@ module Command_line: sig
             unit Genspio.EDSL.t)
            Genspio.EDSL.Command_line.cli_options
           
-           so the second argument must have type:
+           so the action function (the second argument to parse) must have type:
 
            anon:string list Genspio.EDSL.t ->
            string Genspio.EDSL.t ->


### PR DESCRIPTION
This is a follow up to PR #49.

`make doc` gives:

![image](https://cloud.githubusercontent.com/assets/617111/23676570/27470974-034b-11e7-9704-944f27f2e5f3.png)
