### PR TITLE
EDSL.pipe

### DIFF
--- a/src/lib/EDSL.mli
+++ b/src/lib/EDSL.mli
@@ -220,6 +220,15 @@ val write_output :
 
 val write_stdout : path: string t -> unit t -> unit t
 
+
+val pipe: unit t list -> unit t
+(** Pipe commands together (["stdout"] into ["stdin"] exactly like the
+    [" | "] operator). *)
+
+val (||>) : unit t -> unit t -> unit t
+(** [a ||> b] is a shortcut for [pipe [a; b]]. *)
+
+
 val eprintf : string t -> string t list -> unit t
 
 (** {3 Escaping The Execution Flow } *)

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -1145,12 +1145,12 @@ let () = add_tests @@ begin
             ] |> output_as_string in
           let fed =
             bag >> pipe [
-              exec ["sed"; "s/Hello/Ciao/"]
+              exec ["tr"; "H"; "B"];
             ] |> output_as_string in
           seq [
             eprintf (string "Bag: %s") [bag];
             assert_or_fail "pipe-basic1" (bag =$= string "HelloWorld");
-            assert_or_fail "pipe-basic2" (fed =$= string "CiaoWorld");
+            assert_or_fail "pipe-basic2" (fed =$= string "BelloWorld");
             return 13;
           ]
         );

--- a/src/test/main.ml
+++ b/src/test/main.ml
@@ -1132,6 +1132,68 @@ let () = add_tests @@ begin
     ]
   end
 
+let () = add_tests @@ begin
+    List.concat [
+      exits 13 ~name:"pipe-basic" Genspio.EDSL.(
+          let bag =
+            pipe [
+              exec ["printf"; "hello-world\\n"];
+              exec ["tr"; "-d"; "-"];
+              exec ["sed"; "s/wo/Wo/"];
+              exec ["sed"; "s/h/H/"];
+              exec ["tr"; "-d"; "\\n"];
+            ] |> output_as_string in
+          let fed =
+            bag >> pipe [
+              exec ["sed"; "s/Hello/Ciao/"]
+            ] |> output_as_string in
+          seq [
+            eprintf (string "Bag: %s") [bag];
+            assert_or_fail "pipe-basic1" (bag =$= string "HelloWorld");
+            assert_or_fail "pipe-basic2" (fed =$= string "CiaoWorld");
+            return 13;
+          ]
+        );
+      exits 42 ~name:"pipe-xargs" Genspio.EDSL.(
+          seq [
+            assert_or_fail "pipe-xargs-1" (
+              output_as_string
+                (exec ["printf"; "1\\n2\\n3\\n"]
+                 ||> exec ["xargs"; "printf"; "%02d:%02d:%02d"])
+              =$= string "01:02:03"
+            );
+            return 42;
+          ]
+        );
+      exits 42 ~name:"pipe-escape" Genspio.EDSL.(
+          let tmp1 = tmp_file "pipe-escape-1" in
+          let tmp2 = tmp_file "pipe-escape-2" in
+          let tubes =
+            with_signal
+              ~catch:(tmp1#set (string "ok"))
+              (fun jump ->
+                 tmp2#set (
+                   pipe [
+                     exec ["echo"; "hello world"];
+                     jump;
+                     exec ["tr"; "-d"; " "];
+                   ]
+                   |> output_as_string
+                 )
+              )
+          in
+          seq [
+            tmp1#set (string "init1");
+            tmp2#set (string "init2");
+            tubes;
+            assert_or_fail "tmp1-ok" (tmp1#get =$= string "ok");
+            eprintf (string "Tmp2: %s.") [tmp2#get]; 
+            assert_or_fail "tmp2-init" (tmp2#get =$= string "init2");
+            return 42;
+          ]
+        );
+    ]
+  end
 
 
 let () =

--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -72,7 +72,14 @@ genspio_examples=_build/src/test/genspio-examples.byte
 echo "================== TEST 0 ======================================================"
 export single_test_timeout=20.
 export verbose_tests=true
-$gennspio_test
+if $gennspio_test
+then
+    echo "Tests OK"
+else
+    echo "Dash Failures:"
+    cat /tmp/genspio-test-dash-failures.txt
+    exit 2
+fi
 
 # We also run the example
 # we get the script and then we test it


### PR DESCRIPTION

This was possible but very heavy.

```ocaml
let (||>) left right =(* was *)
    output_as_string left >> right
```

which is fine but interleaves pipes with conversions to Genspio's string representation.

The "in-language" solution is much more efficient.

