### PR TITLE
Darwin vm test

### DIFF
--- a/src/examples/vm_tester.ml
+++ b/src/examples/vm_tester.ml
@@ -393,7 +393,24 @@ module Run_environment = struct
       in
       let setup = more_setup in
       let root_password = "root" in
-      qemu_amd46 "qemu_amd46_freebsd" ~hda:qcow ~setup ~root_password ~ui:`Curses
+      qemu_amd46 "qemu_amd64_freebsd" ~hda:qcow ~setup ~root_password
+        ~ui:`Curses
+        ~local_dependencies:[`Command "qemu-system-x86_64"; `Command "sshpass"]
+        ~ssh_port
+
+    let qemu_amd64_darwin ~ssh_port more_setup =
+      (*
+         Made with these instructions: http://althenia.net/notes/darwin
+         from http://www.opensource.apple.com/static/iso/darwinx86-801.iso.gz
+      *)
+      let qcow =
+        http ~act:`Xz
+          "https://www.dropbox.com/s/2oeuya0isvorsam/darwin-disk-20180730.qcow2.xz?raw=1"
+      in
+      let setup = more_setup in
+      let root_password = "root" in
+      qemu_amd46 "qemu_amd64_darwin" ~hda:qcow ~setup ~root_password
+        ~ui:`No_graphic
         ~local_dependencies:[`Command "qemu-system-x86_64"; `Command "sshpass"]
         ~ssh_port
   end
@@ -432,6 +449,8 @@ let () =
         Run_environment.Example.qemu_arm_wheezy ~ssh_port:20023 more_setup
     | "amd64-fb" ->
         Run_environment.Example.qemu_amd64_freebsd ~ssh_port:20024 more_setup
+    | "amd64-dw" ->
+        Run_environment.Example.qemu_amd64_darwin ~ssh_port:20025 more_setup
     | other -> fail "Don't know VM %S" other
   in
   let path = List.nth_exn args 1 in


### PR DESCRIPTION

It's an old, very old, version of Darwin.

```
charles:~ root# sh -version
GNU bash, version 2.05b.0(1)-release (powerpc-apple-darwin8.0.0)
Copyright (C) 2002 Free Software Foundation, Inc.
```


38 tests fail
→ often with the same ``line X: bad substitution: no `)'``
(cf. issue [`hammerlab/genspio#68`](https://github.com/hammerlab/genspio/issues/68))

```
# find _log/ -name "*stderr.txt" |xargs grep 'bad substi' | awk -F: '{ print $1 } ' | sort -u | wc -l
44
```
