### PR TITLE
Fix handling of list items for “ascii comparison”

### DIFF
--- a/src/lib/to_slow_flow.ml
+++ b/src/lib/to_slow_flow.ml
@@ -160,7 +160,7 @@ In that case, we compare the octal representations.
     | Tmp_file_in_variable f ->
         (* Parameters.(tmp_file_db := f :: !tmp_file_db) ; *)
         Fmt.str "$(cat \"${%s}\" | od -t o1 -An -v | tr -d ' \\n')" f
-    | Octal_value_in_variable var -> Fmt.str "${%s}" var
+    | Octal_value_in_variable var -> Fmt.str "$(printf ${%s} | tr -d L)" var
 
   let commands s = s.commands
 


### PR DESCRIPTION
- This fixes #102 for the slow-flow compiler.
- It also adds a regression test for that particular case.